### PR TITLE
URL Cleanup

### DIFF
--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/wrapped_lines/bin/setenv.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/wrapped_lines/bin/setenv.sh
@@ -9,7 +9,7 @@ OTHER_JVM_OPTION="-Xms64m"
 GENERAL_JVM_OPTS="-Xmx512m ${OTHER_JVM_OPTION} -Xss192k"
 
 # JVM Sun specific settings
-# For a complete list http://blogs.sun.com/watt/resource/jvm-options-list.html
+# For a complete list https://blogs.oracle.com/roller-ui/errors/404.jsp
 SUN_JVM_OPTS="-XX:MaxPermSize=192m \
               -XX:MaxGCPauseMillis=500 \
               -XX:+HeapDumpOnOutOfMemoryError"

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/bin/setenv.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/bin/setenv.sh
@@ -7,7 +7,7 @@
 GENERAL_JVM_OPTS="-Xmx512m -Xss192k"
 
 # JVM Sun specific settings
-# For a complete list http://blogs.sun.com/watt/resource/jvm-options-list.html
+# For a complete list https://blogs.oracle.com/roller-ui/errors/404.jsp
 #SUN_JVM_OPTS="-XX:MaxPermSize=192m \
 #              -XX:MaxGCPauseMillis=500 \
 #              -XX:+HeapDumpOnOutOfMemoryError"

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/cpappend.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/cpappend.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/digest.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/digest.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/digest.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/digest.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setclasspath.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setclasspath.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setclasspath.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setclasspath.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setenv.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/setenv.sh
@@ -7,7 +7,7 @@
 GENERAL_JVM_OPTS="-Xmx512m -Xss192k"
 
 # JVM Sun specific settings
-# For a complete list http://blogs.sun.com/watt/resource/jvm-options-list.html
+# For a complete list https://blogs.oracle.com/roller-ui/errors/404.jsp
 #SUN_JVM_OPTS="-XX:MaxPermSize=192m \
 #              -XX:MaxGCPauseMillis=500 \
 #              -XX:+HeapDumpOnOutOfMemoryError"

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/shutdown.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/shutdown.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/shutdown.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/shutdown.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/startup.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/startup.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/startup.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/startup.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/tool-wrapper.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/tool-wrapper.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/tool-wrapper.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/tool-wrapper.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/version.bat
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/version.bat
@@ -6,7 +6,7 @@ rem The ASF licenses this file to You under the Apache License, Version 2.0
 rem (the "License"); you may not use this file except in compliance with
 rem the License.  You may obtain a copy of the License at
 rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
+rem     https://www.apache.org/licenses/LICENSE-2.0
 rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/version.sh
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/version.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://blogs.sun.com/watt/resource/jvm-options-list.html (301) migrated to:  
  https://blogs.oracle.com/roller-ui/errors/404.jsp ([https](https://blogs.sun.com/watt/resource/jvm-options-list.html) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).