### PR TITLE
URL Cleanup

### DIFF
--- a/com.springsource.hq.plugin.tcserver.appmgmt.domain/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.appmgmt.domain/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+        xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
         version="1.3">
 
     <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.client/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.client/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.commandline/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.commandline/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.commandline/src/main/resources/META-INF/spring/tcsadmin-context.xml
+++ b/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.commandline/src/main/resources/META-INF/spring/tcsadmin-context.xml
@@ -20,8 +20,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.5.xsd">
 	<bean id="commandDispatcher"
 		class="com.springsource.hq.plugin.tcserver.cli.commandline.DefaultCommandDispatcher">
 		<constructor-arg>

--- a/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.xjcplugin/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.cli/com.springsource.hq.plugin.tcserver.cli.xjcplugin/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
 	<info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}"/>

--- a/com.springsource.hq.plugin.tcserver.javautil/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.javautil/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
 	<info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}"/>

--- a/com.springsource.hq.plugin.tcserver.plugin/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <!-- ======================== Introduction ============================== -->
     <!-- This document defines default values for *all* web applications      -->
     <!-- loaded into this instance of Tomcat.  As each application is         -->

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <!-- ======================== Introduction ============================== -->
     <!-- This document defines default values for *all* web applications      -->
     <!-- loaded into this instance of Tomcat.  As each application is         -->

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5">
 
   <display-name>Welcome to tc Server</display-name>

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5">
 
   <display-name>Welcome to tc Server</display-name>

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5"> 
 
   <display-name>Tomcat Manager Application</display-name>

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5"> 
 
   <display-name>Tomcat Manager Application</display-name>

--- a/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
+++ b/com.springsource.hq.plugin.tcserver.plugin/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->

--- a/com.springsource.hq.plugin.tcserver.serverconfig.domain/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.domain/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/build.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/build.xml
@@ -65,7 +65,7 @@
 
 	<target name="dojo.download">
 		<mkdir dir="${target.dir}"/>
-		<get src="http://download.dojotoolkit.org/release-${dojo.version}/dojo-release-${dojo.version}-src.zip"
+		<get src="https://download.dojotoolkit.org/release-${dojo.version}/dojo-release-${dojo.version}-src.zip"
 				dest="${target.dir}" usetimestamp="true" verbose="true"/>
 		<path id="dojo.path">
 			<pathelement location="${target.dir}/dojo-release-${dojo.version}-src.zip"/>

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/META-INF/security-context.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/META-INF/security-context.xml
@@ -21,9 +21,9 @@
   xmlns:beans="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans 
-  	http://www.springframework.org/schema/beans/spring-beans-3.0.xsd 
+  	https://www.springframework.org/schema/beans/spring-beans-3.0.xsd 
   	http://www.springframework.org/schema/security 
-  	http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+  	https://www.springframework.org/schema/security/spring-security-3.0.xsd">
   	
   	<!-- This is coded using security namespaces as the default. Not sure if it fails if you swap it with beans and security, but highly recommended
   	to keep it this way. -->

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/config/web-application-config.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/config/web-application-config.xml
@@ -22,9 +22,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+           https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<!-- Scans for application @Components to deploy -->
 	<context:component-scan base-package="com.springsource.hq.plugin.tcserver.serverconfig" />

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/layouts/layouts.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/layouts/layouts.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE tiles-definitions PUBLIC
        "-//Apache Software Foundation//DTD Tiles Configuration 2.0//EN"
-       "http://tiles.apache.org/dtds/tiles-config_2_0.dtd">
+       "https://tiles.apache.org/dtds/tiles-config_2_0.dtd">
 
 <tiles-definitions>
 	

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/views.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/views.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE tiles-definitions PUBLIC
 	"-//Apache Software Foundation//DTD Tiles Configuration 2.0//EN"
-	"http://tiles.apache.org/dtds/tiles-config_2_0.dtd">
+	"https://tiles.apache.org/dtds/tiles-config_2_0.dtd">
 
 <tiles-definitions>
 	

--- a/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/web.xml
+++ b/com.springsource.hq.plugin.tcserver.serverconfig.web/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
 	version="2.4">
 
 	<!-- The master configuration file for this Spring web application -->

--- a/com.springsource.hq.plugin.tcserver.ui.tcserverclient/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.ui.tcserverclient/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.ui.tomcatappmgmt/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.ui.tomcatappmgmt/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.ui.tomcatserverconfig/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.ui.tomcatserverconfig/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
         <info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">

--- a/com.springsource.hq.plugin.tcserver.util/ivy.xml
+++ b/com.springsource.hq.plugin.tcserver.util/ivy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://ivyrep.jayasoft.org/ivy-doc.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://ivyrep.jayasoft.org/ivy-doc.xsl"?>
 <!--
   ~ Copyright (C) 2009-2015  Pivotal Software, Inc
   ~
@@ -19,7 +19,7 @@
 
 <ivy-module
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://incubator.apache.org/ivy/schemas/ivy.xsd"
+		xsi:noNamespaceSchemaLocation="https://incubator.apache.org/ivy/schemas/ivy.xsd"
 		version="1.3">
 
 	<info organisation="com.springsource.hq.plugin.tcserver" module="${ant.project.name}">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.hyperic.org/external (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/external) result SSLHandshakeException).
* http://maven.hyperic.org/hqapi/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/hqapi/milestone) result SSLHandshakeException).
* http://maven.hyperic.org/hqapi/release (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/hqapi/release) result SSLHandshakeException).
* http://maven.hyperic.org/hqapi/snapshot (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/hqapi/snapshot) result SSLHandshakeException).
* http://maven.hyperic.org/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/milestone) result SSLHandshakeException).
* http://maven.hyperic.org/release (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/release) result SSLHandshakeException).
* http://maven.hyperic.org/snapshot (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/snapshot) result SSLHandshakeException).
* http://private.maven.hyperic.com/external (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.hyperic.com/external) result SSLHandshakeException).
* http://private.maven.hyperic.com/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.hyperic.com/milestone) result SSLHandshakeException).
* http://private.maven.hyperic.com/release (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.hyperic.com/release) result SSLHandshakeException).
* http://private.maven.hyperic.com/snapshot (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.hyperic.com/snapshot) result SSLHandshakeException).
* http://private.maven.springsource.com/external (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.springsource.com/external) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://ivyrep.jayasoft.org/ivy-doc.xsl (UnknownHostException) with 12 occurrences migrated to:  
  https://ivyrep.jayasoft.org/ivy-doc.xsl ([https](https://ivyrep.jayasoft.org/ivy-doc.xsl) result UnknownHostException).
* http://download.dojotoolkit.org/release- (301) with 1 occurrences migrated to:  
  https://download.dojotoolkit.org/release- ([https](https://download.dojotoolkit.org/release-) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tiles.apache.org/dtds/tiles-config_2_0.dtd with 2 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_2_0.dtd ([https](https://tiles.apache.org/dtds/tiles-config_2_0.dtd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-3.0.xsd ([https](https://www.springframework.org/schema/security/spring-security-3.0.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-2.5.xsd ([https](https://www.springframework.org/schema/util/spring-util-2.5.xsd) result 200).
* http://incubator.apache.org/ivy/schemas/ivy.xsd with 12 occurrences migrated to:  
  https://incubator.apache.org/ivy/schemas/ivy.xsd ([https](https://incubator.apache.org/ivy/schemas/ivy.xsd) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 9 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://java.sun.com/xml/ns/javaee with 18 occurrences
* http://www.springframework.org/schema/beans with 6 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/p with 1 occurrences
* http://www.springframework.org/schema/security with 2 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 25 occurrences